### PR TITLE
[CMS-553] Add pending packages from composer require and require-dev sections.

### DIFF
--- a/src/Commands/ConvertToComposerSiteCommand.php
+++ b/src/Commands/ConvertToComposerSiteCommand.php
@@ -232,14 +232,13 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
      */
     private function copyComposerInstallersExtenderConfiguration($originalRootComposerJson)
     {
-        // @todo This is untested!
         $packageName = 'oomphinc/composer-installers-extender';
         if (!isset($originalRootComposerJson['require'][$packageName]) && !isset($originalRootComposerJson['require-dev'][$packageName])) {
             return;
         }
         $currentComposerJson = $this->getComposer()->getComposerJsonData();
-        if (isset($currentComposerJson['extra']['installer-types'])) {
-            $installerTypes = $currentComposerJson['extra']['installer-types'];
+        if (isset($originalRootComposerJson['extra']['installer-types'])) {
+            $installerTypes = $originalRootComposerJson['extra']['installer-types'];
             $currentComposerJson['extra']['installer-types'] = $originalRootComposerJson['extra']['installer-types'];
             foreach ($originalRootComposerJson['extra']['installer-paths'] ?? [] as $path => $types) {
                 if (array_intersect($installerTypes, $types)) {
@@ -255,7 +254,6 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
      */
     private function copyExtraComposerInstallersConfiguration($originalRootComposerJson)
     {
-        // @todo This is untested!
         $currentComposerJson = $this->getComposer()->getComposerJsonData();
         if (isset($currentComposerJson['extra']['installer-paths'])) {
             $installerPaths = &$currentComposerJson['extra']['installer-paths'];
@@ -264,7 +262,7 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
                     $installerPaths[$path] = $types;
                 } else {
                     if ($installerPaths[$path] !== $types) {
-                        $installerPaths[$path] = array_merge($installerPaths[$path], $types);
+                        $installerPaths[$path] = array_values(array_unique(array_merge($installerPaths[$path], $types)));
                     }
                 }
             }

--- a/src/Commands/ConvertToComposerSiteCommand.php
+++ b/src/Commands/ConvertToComposerSiteCommand.php
@@ -191,6 +191,7 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
     {
         $this->copyComposerPatchesConfiguration($originalRootComposerJson);
         $this->copyComposerInstallersExtenderConfiguration($originalRootComposerJson);
+        $this->copyExtraComposerInstallersConfiguration($originalRootComposerJson);
         if ($this->getGit()->isAnythingToCommit()) {
             $this->getGit()->commit('Copy extra composer configuration.');
         } else {
@@ -243,6 +244,28 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
             foreach ($originalRootComposerJson['extra']['installer-paths'] ?? [] as $path => $types) {
                 if (array_intersect($installerTypes, $types)) {
                     $currentComposerJson['extra']['installer-paths'][$path] = $types;
+                }
+            }
+        }
+        $this->getComposer()->writeComposerJsonData($currentComposerJson);
+    }
+
+    /**
+     * Copy extra composer/installer configuration if exists.
+     */
+    private function copyExtraComposerInstallersConfiguration($originalRootComposerJson)
+    {
+        // @todo This is untested!
+        $currentComposerJson = $this->getComposer()->getComposerJsonData();
+        if (isset($currentComposerJson['extra']['installer-paths'])) {
+            $installerPaths = &$currentComposerJson['extra']['installer-paths'];
+            foreach ($originalRootComposerJson['extra']['installer-paths'] ?? [] as $path => $types) {
+                if (!isset($installerPaths[$path])) {
+                    $installerPaths[$path] = $types;
+                } else {
+                    if ($installerPaths[$path] !== $types) {
+                        $installerPaths[$path] = array_merge($installerPaths[$path], $types);
+                    }
                 }
             }
         }

--- a/src/Commands/ConvertToComposerSiteCommand.php
+++ b/src/Commands/ConvertToComposerSiteCommand.php
@@ -558,6 +558,7 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
     {
         $this->log()->notice('Adding packages to Composer...');
         foreach ($packages as $project) {
+            $arguments = [];
             if (is_string($project)) {
                 $project = [
                     'package' => $project,
@@ -572,6 +573,7 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
             }
             $options = $project['is_dev'] ? ['--dev'] : [];
             $options[] = '-n';
+            $options[] = '-W';
             try {
                 $this->getComposer()->require(...$arguments, ...$options);
                 $this->getGit()->commit(sprintf('Add %s project to Composer', $package));

--- a/src/Commands/ConvertToComposerSiteCommand.php
+++ b/src/Commands/ConvertToComposerSiteCommand.php
@@ -255,15 +255,24 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
     private function copyExtraComposerInstallersConfiguration($originalRootComposerJson)
     {
         $currentComposerJson = $this->getComposer()->getComposerJsonData();
-        if (isset($currentComposerJson['extra']['installer-paths'])) {
-            $installerPaths = &$currentComposerJson['extra']['installer-paths'];
-            foreach ($originalRootComposerJson['extra']['installer-paths'] ?? [] as $path => $types) {
-                if (!isset($installerPaths[$path])) {
-                    $installerPaths[$path] = $types;
-                } else {
-                    if ($installerPaths[$path] !== $types) {
-                        $installerPaths[$path] = array_values(array_unique(array_merge($installerPaths[$path], $types)));
+        $currentTypes = [];
+
+        $installerPaths = &$currentComposerJson['extra']['installer-paths'] ?? [];
+        foreach ($installerPaths as $path => $types) {
+            $currentTypes += $types;
+        }
+
+        foreach ($originalRootComposerJson['extra']['installer-paths'] ?? [] as $path => $types) {
+            if (!isset($installerPaths[$path])) {
+                foreach ($types as $type) {
+                    if (in_array($type, $currentTypes)) {
+                        continue;
                     }
+                    $installerPaths[$path][] = $type;
+                }
+            } else {
+                if ($installerPaths[$path] !== $types) {
+                    $installerPaths[$path] = array_values(array_unique(array_merge($installerPaths[$path], $types)));
                 }
             }
         }

--- a/src/Commands/ConvertToComposerSiteCommand.php
+++ b/src/Commands/ConvertToComposerSiteCommand.php
@@ -558,7 +558,6 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
     {
         $this->log()->notice('Adding packages to Composer...');
         foreach ($packages as $project) {
-            $arguments = [];
             if (is_string($project)) {
                 $project = [
                     'package' => $project,
@@ -568,9 +567,6 @@ class ConvertToComposerSiteCommand extends TerminusCommand implements SiteAwareI
             }
             $package = $project['package'];
             $arguments = [$project['package'], $project['version']];
-            if ($project['is_dev']) {
-                $arguments[] = '--dev';
-            }
             $options = $project['is_dev'] ? ['--dev'] : [];
             $options[] = '-n';
             $options[] = '-W';

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -108,4 +108,13 @@ class Composer
         $filePath = Files::buildPath($this->projectPath, 'composer.json');
         return json_decode(file_get_contents($filePath), true);
     }
+
+    /**
+     * Write given array as composer.json.
+     */
+    public function writeComposerJsonData(array $data)
+    {
+        $filePath = Files::buildPath($this->projectPath, 'composer.json');
+        return file_put_contents($filePath, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_LINE_TERMINATORS | JSON_UNESCAPED_UNICODE));
+    }
 }

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -53,7 +53,7 @@ class Composer
         if (null !== $version) {
             $this->execute(['composer', 'require', sprintf('%s:%s', $package, $version), ...$options]);
         } else {
-            $this->execute(['composer', 'require', $package]);
+            $this->execute(['composer', 'require', $package, ...$options]);
         }
     }
 
@@ -103,7 +103,7 @@ class Composer
     /**
      * Returns current composer.json as an array.
      */
-    public function toArray(): array
+    public function getComposerJsonData(): array
     {
         $filePath = Files::buildPath($this->projectPath, 'composer.json');
         return json_decode(file_get_contents($filePath), true);

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -115,6 +115,6 @@ class Composer
     public function writeComposerJsonData(array $data)
     {
         $filePath = Files::buildPath($this->projectPath, 'composer.json');
-        return file_put_contents($filePath, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_LINE_TERMINATORS | JSON_UNESCAPED_UNICODE));
+        return file_put_contents($filePath, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_LINE_TERMINATORS | JSON_UNESCAPED_UNICODE) . PHP_EOL);
     }
 }

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -99,4 +99,13 @@ class Composer
             );
         }
     }
+
+    /**
+     * Returns current composer.json as an array.
+     */
+    public function toArray(): array
+    {
+        $filePath = Files::buildPath($this->projectPath, 'composer.json');
+        return json_decode(file_get_contents($filePath), true);
+    }
 }


### PR DESCRIPTION
After copying regular modules, themes and libraries, conversion:composer now compares original and actual composer.json and adds the missing packages both in require and require-dev sections.

Also, copy extra configuration for some well-known plugins (installer-extenders, installers and composer-patches).

I also added a couple of notices when this process finishes.