### PR TITLE
[CMS-630] Create a command in conversion tool to validate .gitignore

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,22 +32,22 @@ jobs:
     strategy:
       matrix:
         testing_groups:
-#          - name: on drops-8 upstream
-#            group: upstream_drops8
-#          - name: on drops-9 upstream
-#            group: upstream_drops9
-#          - name: on empty upstream
-#            group: upstream_empty
-#          - name: on drupal-project upstream
-#            group: upstream_drupal_project
-#          - name: conversion:advise command scenarios on empty upstream
-#            group: advise_scenarios_empty_upstream
-#          - name: conversion:push-to-multidev command
-#            group: push_to_md_command
-#          - name: conversion:enable-ic command
-#            group: enable_integrated_composer_command
-#          - name: conversion:import-site command
-#            group: site_import
+          - name: on drops-8 upstream
+            group: upstream_drops8
+          - name: on drops-9 upstream
+            group: upstream_drops9
+          - name: on empty upstream
+            group: upstream_empty
+          - name: on drupal-project upstream
+            group: upstream_drupal_project
+          - name: conversion:advise command scenarios on empty upstream
+            group: advise_scenarios_empty_upstream
+          - name: conversion:push-to-multidev command
+            group: push_to_md_command
+          - name: conversion:enable-ic command
+            group: enable_integrated_composer_command
+          - name: conversion:import-site command
+            group: site_import
           - name: conversion:validate-gitignore
             group: validate_and_fix_gitignore_command
       fail-fast: false

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,22 +32,24 @@ jobs:
     strategy:
       matrix:
         testing_groups:
-          - name: on drops-8 upstream
-            group: upstream_drops8
-          - name: on drops-9 upstream
-            group: upstream_drops9
-          - name: on empty upstream
-            group: upstream_empty
-          - name: on drupal-project upstream
-            group: upstream_drupal_project
-          - name: conversion:advise command scenarios on empty upstream
-            group: advise_scenarios_empty_upstream
-          - name: conversion:push-to-multidev command
-            group: push_to_md_command
-          - name: conversion:enable-ic command
-            group: enable_integrated_composer_command
-          - name: conversion:import-site command
-            group: site_import
+#          - name: on drops-8 upstream
+#            group: upstream_drops8
+#          - name: on drops-9 upstream
+#            group: upstream_drops9
+#          - name: on empty upstream
+#            group: upstream_empty
+#          - name: on drupal-project upstream
+#            group: upstream_drupal_project
+#          - name: conversion:advise command scenarios on empty upstream
+#            group: advise_scenarios_empty_upstream
+#          - name: conversion:push-to-multidev command
+#            group: push_to_md_command
+#          - name: conversion:enable-ic command
+#            group: enable_integrated_composer_command
+#          - name: conversion:import-site command
+#            group: site_import
+          - name: conversion:validate-gitignore
+            group: validate_and_fix_gitignore_command
       fail-fast: false
     runs-on: ubuntu-latest
     name: Testing ${{ matrix.testing_groups.name }}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Adds the following Terminus commands:
 * `conversion:restore-master`
 * `conversion:enable-ic`
 * `conversion:import-site`
+* `conversion:validate-gitignore`
 
 Learn more about Terminus Plugins in the [Terminus Plugins documentation](https://pantheon.io/docs/terminus/plugins)
 
@@ -32,6 +33,7 @@ In active development
 * Run `terminus conversion:restore-master` to restore the master branch to its original state
 * Run `terminus conversion:enable-ic` to enable Pantheon Integrated Composer for the site
 * Run `terminus conversion:import-site` to create a site based on "drupal-recommended" upstream from imported code, database, and files
+* Run `conversion:validate-gitignore` to validate Git/Composer project and update .gitignore file accordingly
 
 ## Installation
 

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -9,6 +9,7 @@ use Pantheon\TerminusConversionTools\Commands\Traits\ComposerAwareTrait;
 use Pantheon\TerminusConversionTools\Commands\Traits\ConversionCommandsTrait;
 use Pantheon\TerminusConversionTools\Exceptions\TerminusCancelOperationException;
 use Pantheon\TerminusConversionTools\Utils\Files;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Class ValidateAndFixGitignoreCommand.
@@ -34,19 +35,20 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
      * @throws \Pantheon\TerminusConversionTools\Exceptions\TerminusCancelOperationException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
      */
     public function validateAndFixGitignore(string $site_id): void
     {
         $this->setSite($site_id);
 
-        $this->gitignoreFilePath = Files::buildPath($this->getLocalSitePath(), '.gitignore');
-        $this->validateGitignoreExists();
-
-        $this->setGit($this->getLocalSitePath());
-
         $this->setComposer($this->getLocalSitePath());
         $this->log()->notice('Installing Composer dependencies...');
         $this->getComposer()->install();
+
+        $this->gitignoreFilePath = Files::buildPath($this->getLocalSitePath(), '.gitignore');
+        $this->setGit($this->getLocalSitePath());
+        $this->validateGitignoreExists();
+
         $installationPaths = $this->getComposer()->getInstallationPaths();
 
         // 1. clone site
@@ -54,8 +56,9 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         // 2. check for existing .gitignore file
         // 3. install dependencies
         // 4. analyze
-        //    - "vendor" must be always ignored
+        //    - get Composer installation paths
         // 5. suggest fixes
+        //    - "vendor" must be always ignored
         // 6. confirm fixes
         // 7. apply fixes
 
@@ -65,6 +68,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
     /**
      * Validates the .gitignore file exists, otherwise suggests creating it automatically.
      *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
      * @throws \Pantheon\TerminusConversionTools\Exceptions\TerminusCancelOperationException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      * @throws \Psr\Container\ContainerExceptionInterface
@@ -78,7 +82,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         if (!$this->input()->getOption('yes')
             && !$this->io()->confirm(
                 sprintf(
-                    'File .gitignore not found in "%s". Do you want to create it?',
+                    'File .gitignore not found in "%s". Do you want to create and commit it?',
                     $this->getLocalSitePath()
                 )
             )
@@ -91,10 +95,41 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
             );
         }
 
-        if (!file_put_contents($this->gitignoreFilePath, '# Created by Terminus Conversion Tools Plugin.' . PHP_EOL)) {
+        if (!file_put_contents($this->gitignoreFilePath, '# Added by Terminus Conversion Tools Plugin.' . PHP_EOL)) {
             throw new TerminusException(
                 sprintf('Failed to create .gitignore file in "%s".', $this->getLocalSitePath())
             );
         }
+        $this->getGit()->commit('Add .gitignore', ['.gitignore']);
+
+        $fs = new Filesystem();
+        $defaultPathsToIgnore = array_filter(
+            ['vendor'],
+            fn($path) => $fs->exists($path)
+        );
+
+        foreach ($defaultPathsToIgnore as $path) {
+            $this->addPathToIgnore($path);
+        }
+    }
+
+    /**
+     * Adds a path to .gitignore.
+     *
+     * @param string $path
+     *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
+     */
+    private function addPathToIgnore(string $path): void
+    {
+        $this->log()->notice(sprintf('Adding "%s" to .gitignore...', $path));
+
+        $gitignoreFile = fopen($this->gitignoreFilePath, 'a');
+        fwrite($gitignoreFile, $path);
+        fclose($gitignoreFile);
+        $this->getGit()->commit(sprintf('Add "%s" to .gitignore', $path), ['.gitignore']);
+
+        $this->getGit()->remove('-r', '--cached', $path);
+        $this->getGit()->commit(sprintf('Remove ignored path "%s"', $path), ['-u']);
     }
 }

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Pantheon\TerminusConversionTools\Commands;
+
+use Pantheon\Terminus\Commands\TerminusCommand;
+use Pantheon\Terminus\Exceptions\TerminusException;
+use Pantheon\Terminus\Site\SiteAwareInterface;
+use Pantheon\TerminusConversionTools\Commands\Traits\ComposerAwareTrait;
+use Pantheon\TerminusConversionTools\Commands\Traits\ConversionCommandsTrait;
+use Pantheon\TerminusConversionTools\Exceptions\TerminusCancelOperationException;
+use Pantheon\TerminusConversionTools\Utils\Files;
+
+/**
+ * Class ValidateAndFixGitignoreCommand.
+ */
+class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwareInterface
+{
+    use ConversionCommandsTrait;
+    use ComposerAwareTrait;
+
+    /**
+     * @var string
+     */
+    private $gitignoreFilePath;
+
+    /**
+     * Validates Git/Composer project and suggests tweaks to .gitignore file.
+     *
+     * @command conversion:validate-gitignore
+     *
+     * @param string $site_id
+     *
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Psr\Container\ContainerExceptionInterface
+     */
+    public function validateAndFixGitignore(string $site_id): void
+    {
+        $this->setSite($site_id);
+
+        $this->gitignoreFilePath = Files::buildPath($this->getLocalSitePath(), '.gitignore');
+        $this->validateGitignoreExists();
+
+        $this->setGit($this->getLocalSitePath());
+        $this->setComposer($this->getLocalSitePath());
+
+        // 1. clone site
+        //    @todo: provide a path to local cloned copy if exists
+        // 1.1 install dependencies
+        // 2. check for existing .gitignore file
+        // 3. validate
+        //    - "vendor" must be always ignored
+        // 4. suggest fixes
+        // 5. confirm fixes
+        // 6. apply fixes
+
+        $this->log()->notice('Done!');
+    }
+
+    /**
+     * Validates the .gitignore file exists, otherwise suggests creating it automatically.
+     *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\TerminusCancelOperationException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
+     * @throws \Psr\Container\ContainerExceptionInterface
+     */
+    protected function validateGitignoreExists(): void
+    {
+        if (is_file($this->gitignoreFilePath)) {
+            return;
+        }
+
+        if (!$this->input()->getOption('yes')
+            && !$this->io()->confirm(
+                sprintf(
+                    'File .gitignore not found in "%s". Do you want to create it?',
+                    $this->getLocalSitePath()
+                )
+            )
+        ) {
+            throw new TerminusCancelOperationException(
+                sprintf(
+                    'Create .gitignore file in "%s" operation has not been confirmed.',
+                    $this->getLocalSitePath()
+                )
+            );
+        }
+
+        if (!file_put_contents($this->gitignoreFilePath, '# Created by Terminus Conversion Tools Plugin.' . PHP_EOL)) {
+            throw new TerminusException(
+                sprintf('Failed to create .gitignore file in "%s".', $this->getLocalSitePath())
+            );
+        }
+    }
+}

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -90,7 +90,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
             // Remove all installation paths that starts with $pathParent...
             $installationPathsProcessed = array_filter(
                 $installationPathsProcessed,
-                fn($path) => 0 !== strpos($path, $pathParent)
+                fn($path) => is_array($path) || 0 !== strpos($path, $pathParent)
             );
             // ...and replace with a single complex rule instead.
             $installationPathsProcessed[] = [

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -159,7 +159,9 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
      * Adds a path to .gitignore.
      *
      * @param string $pathPattern
+     *   A path or a gitignore path pattern (i.e. /web/themes/composer/*).
      * @param array $subPaths
+     *   An array of sub-paths to ignore. Used with path pattern "/*".
      *
      * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -132,7 +132,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
      */
     private function addPathToIgnore(string $path): void
     {
-        if (!$this->fs->exists($path)) {
+        if (!$this->fs->exists(Files::buildPath($this->getLocalSitePath(), $path))) {
             $this->log()->notice(sprintf('Skipped adding "%s" to .gitignore file: the path does not exist.', $path));
 
             return;
@@ -141,7 +141,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         $this->log()->notice(sprintf('Adding "%s" to .gitignore file...', $path));
 
         $gitignoreFile = fopen($this->gitignoreFilePath, 'a');
-        fwrite($gitignoreFile, $path);
+        fwrite($gitignoreFile, $path . PHP_EOL);
         fclose($gitignoreFile);
         $this->getGit()->commit(sprintf('Add "%s" to .gitignore', $path), ['.gitignore']);
 

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -70,6 +70,9 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         $this->validateGitignoreExists();
 
         $installationPaths = $this->getComposer()->getInstallationPaths();
+        $installationPathsProcessed = array_filter($installationPaths, fn($path) => 0 !== strpos($path, 'vendor/'));
+        array_unshift($installationPathsProcessed, ...$this->getDefaultPathsToIgnore());
+        sort($installationPathsProcessed);
 
         // 1. clone site
         //    @todo: provide a path to local cloned copy if exists

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -141,7 +141,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         $this->log()->notice(sprintf('Adding "%s" to .gitignore file...', $path));
 
         $gitignoreFile = fopen($this->gitignoreFilePath, 'a');
-        fwrite($gitignoreFile, $path . PHP_EOL);
+        fwrite($gitignoreFile, '/' . $path . PHP_EOL);
         fclose($gitignoreFile);
         $this->getGit()->commit(sprintf('Add "%s" to .gitignore', $path), ['.gitignore']);
 

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -69,6 +69,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         $this->setGit($this->getLocalSitePath());
         $this->validateGitignoreExists();
 
+        $this->log()->notice('Analyzing Composer installation paths...');
         $installationPaths = $this->getComposer()->getInstallationPaths();
         $installationPathsProcessed = array_filter(
             $installationPaths,

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -47,6 +47,7 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         $this->setComposer($this->getLocalSitePath());
         $this->log()->notice('Installing Composer dependencies...');
         $this->getComposer()->install();
+        $installationPaths = $this->getComposer()->getInstallationPaths();
 
         // 1. clone site
         //    @todo: provide a path to local cloned copy if exists

--- a/src/Commands/ValidateAndFixGitignoreCommand.php
+++ b/src/Commands/ValidateAndFixGitignoreCommand.php
@@ -30,6 +30,8 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
      *
      * @param string $site_id
      *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Composer\ComposerException
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\TerminusCancelOperationException
      * @throws \Pantheon\Terminus\Exceptions\TerminusException
      * @throws \Psr\Container\ContainerExceptionInterface
      */
@@ -41,17 +43,20 @@ class ValidateAndFixGitignoreCommand extends TerminusCommand implements SiteAwar
         $this->validateGitignoreExists();
 
         $this->setGit($this->getLocalSitePath());
+
         $this->setComposer($this->getLocalSitePath());
+        $this->log()->notice('Installing Composer dependencies...');
+        $this->getComposer()->install();
 
         // 1. clone site
         //    @todo: provide a path to local cloned copy if exists
-        // 1.1 install dependencies
         // 2. check for existing .gitignore file
-        // 3. validate
+        // 3. install dependencies
+        // 4. analyze
         //    - "vendor" must be always ignored
-        // 4. suggest fixes
-        // 5. confirm fixes
-        // 6. apply fixes
+        // 5. suggest fixes
+        // 6. confirm fixes
+        // 7. apply fixes
 
         $this->log()->notice('Done!');
     }

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -97,6 +97,25 @@ class Composer
     }
 
     /**
+     * Returns the list of installation paths.
+     *
+     * @return array
+     *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Composer\ComposerException
+     */
+    public function getInstallationPaths(): array
+    {
+        $pathsJson = $this->execute(['composer', 'info', '--path', '--format=json']);
+
+        $paths = json_decode($pathsJson, true);
+        if (json_last_error()) {
+            throw new ComposerException(sprintf('Failed decoding JSON string: error code %d', json_last_error()));
+        }
+
+        return $paths;
+    }
+
+    /**
      * Executes the Composer command.
      *
      * @param array $command

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -97,7 +97,7 @@ class Composer
     }
 
     /**
-     * Returns the list of installation paths.
+     * Returns the list of relative installation paths.
      *
      * @return array
      *
@@ -117,8 +117,12 @@ class Composer
         }
 
         $installationPaths = array_column($paths['installed'], 'path');
+        $installationPaths = array_filter($installationPaths, fn($path) => $path !== $this->projectPath);
 
-        return array_filter($installationPaths, fn($path) => $path !== $this->projectPath);
+        return array_map(
+            fn($path) => str_replace($this->projectPath . '/', '', $path),
+            $installationPaths
+        );
     }
 
     /**

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -112,7 +112,13 @@ class Composer
             throw new ComposerException(sprintf('Failed decoding JSON string: error code %d', json_last_error()));
         }
 
-        return $paths;
+        if (!isset($paths['installed'])) {
+            return [];
+        }
+
+        $installationPaths = array_column($paths['installed'], 'path');
+
+        return array_filter($installationPaths, fn($path) => $path !== $this->projectPath);
     }
 
     /**

--- a/src/Utils/Composer.php
+++ b/src/Utils/Composer.php
@@ -101,13 +101,17 @@ class Composer
      *
      * @param array $command
      *
+     * @return string
+     *
      * @throws \Pantheon\TerminusConversionTools\Exceptions\Composer\ComposerException
      */
-    private function execute(array $command): void
+    private function execute(array $command): string
     {
         try {
             $process = new Process($command, $this->projectPath, null, null, 180);
             $process->mustRun();
+
+            return $process->getOutput();
         } catch (Throwable $t) {
             throw new ComposerException(
                 sprintf('Failed executing Composer command: %s', $t->getMessage())

--- a/src/Utils/Git.php
+++ b/src/Utils/Git.php
@@ -80,17 +80,17 @@ class Git
      *
      * @param string $commitMessage
      *   The commit message.
-     * @param null|array $files
-     *   The files to stage.
+     * @param null|array $gitAddOptions
+     *   git-add options.
      *
      * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
      */
-    public function commit(string $commitMessage, ?array $files = null): void
+    public function commit(string $commitMessage, ?array $gitAddOptions = null): void
     {
-        if (null === $files) {
-            $this->execute(['add', '-A']);
+        if (null === $gitAddOptions) {
+            $this->add('-A');
         } else {
-            $this->execute(['add', ...$files]);
+            $this->add(...$gitAddOptions);
         }
 
         $this->execute(['commit', '-m', $commitMessage]);
@@ -367,6 +367,19 @@ class Git
     public function getToplevelRepoPath(): string
     {
         return trim($this->execute(['rev-parse', '--show-toplevel']));
+    }
+
+    /**
+     * Adds files to index.
+     *
+     * @param $options
+     *   The list of files and git-add options.
+     *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
+     */
+    private function add(...$options): void
+    {
+        $this->execute(['add', ...$options]);
     }
 
     /**

--- a/src/Utils/Git.php
+++ b/src/Utils/Git.php
@@ -370,6 +370,30 @@ class Git
     }
 
     /**
+     * Returns TRUE if the path is an ignored path.
+     *
+     * @param string $path
+     *
+     * @return bool
+     *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
+     */
+    public function isIgnoredPath(string $path): bool
+    {
+        $process = $this->executeAndReturnProcess(['check-ignore', '--quiet', $path]);
+        switch ($process->getExitCode()) {
+            case 0:
+                return true;
+            case 1:
+                return false;
+            default:
+                throw new GitException(
+                    sprintf('Failed to check if path "%s" is ignored: exit code %d', $path, $process->getExitCode())
+                );
+        }
+    }
+
+    /**
      * Adds files to index.
      *
      * @param $options

--- a/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
+++ b/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
@@ -28,13 +28,14 @@ final class ConversionCommandsValidateAndFixGitignoreTest extends ConversionComm
     {
         $this->terminus(sprintf('conversion:validate-gitignore %s', $this->siteName));
 
-        $localSiteCopyDirName = sprintf('%s_terminus_conversion_plugin', $this->siteName);
-        $gitignoreFilePath = Files::buildPath(
+        $localSiteDirName = sprintf('%s_terminus_conversion_plugin', $this->siteName);
+        $localSitePath = $gitignoreFilePath = Files::buildPath(
             $_SERVER['HOME'],
             'pantheon-local-copies',
-            $localSiteCopyDirName,
-            '.gitignore'
+            $localSiteDirName
         );
+        $gitignoreFilePath = Files::buildPath($localSitePath, '.gitignore');
+
         $this->assertTrue(
             is_file($gitignoreFilePath),
             sprintf('File "%s" must exist', $gitignoreFilePath)

--- a/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
+++ b/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Pantheon\TerminusConversionTools\Tests\Functional;
+
+use Pantheon\TerminusConversionTools\Utils\Files;
+
+/**
+ * Class ConversionCommandsValidateAndFixGitignoreTest.
+ *
+ * @package Pantheon\TerminusConversionTools\Tests\Functional
+ */
+final class ConversionCommandsValidateAndFixGitignoreTest extends ConversionCommandsTestBase
+{
+    /**
+     * @inheritdoc
+     */
+    protected function getUpstreamIdEnvName(): string
+    {
+        return 'TERMINUS_TEST_SITE_NON_IC_UPSTREAM_ID';
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @group validate_and_fix_gitignore_command
+     */
+    public function testConversionCommands(): void
+    {
+        $this->terminus(sprintf('conversion:validate-gitignore %s', $this->siteName));
+
+        $localSiteCopyDirName = sprintf('%s_terminus_conversion_plugin', $this->siteName);
+        $gitignoreFilePath = Files::buildPath(
+            $_SERVER['HOME'],
+            'pantheon-local-copies',
+            $localSiteCopyDirName,
+            '.gitignore'
+        );
+        $this->assertTrue(
+            is_file($gitignoreFilePath),
+            sprintf('File "%s" must exist', $gitignoreFilePath)
+        );
+
+        $this->assertEquals(
+            <<<EOD
+# Added by Terminus Conversion Tools Plugin.
+/vendor
+/web/core
+
+EOD,
+            file_get_contents($gitignoreFilePath)
+        );
+    }
+}

--- a/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
+++ b/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
@@ -45,6 +45,9 @@ final class ConversionCommandsValidateAndFixGitignoreTest extends ConversionComm
 # Added by Terminus Conversion Tools Plugin.
 /vendor
 /web/core
+/web/modules/composer/*
+/web/themes/composer/*
+!/web/themes/composer/this_file_must_not_be_gitignored.txt
 
 EOD,
             file_get_contents($gitignoreFilePath)

--- a/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
+++ b/tests/functional/ConversionCommandsValidateAndFixGitignoreTest.php
@@ -3,9 +3,13 @@
 namespace Pantheon\TerminusConversionTools\Tests\Functional;
 
 use Pantheon\TerminusConversionTools\Utils\Files;
+use Pantheon\TerminusConversionTools\Utils\Git;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Class ConversionCommandsValidateAndFixGitignoreTest.
+ *
+ * Uses a site fixture based on https://github.com/pantheon-fixtures/site-non-ic custom upstream.
  *
  * @package Pantheon\TerminusConversionTools\Tests\Functional
  */
@@ -23,24 +27,28 @@ final class ConversionCommandsValidateAndFixGitignoreTest extends ConversionComm
      * @inheritdoc
      *
      * @group validate_and_fix_gitignore_command
+     *
+     * @throws \Pantheon\TerminusConversionTools\Exceptions\Git\GitException
+     * @throws \Pantheon\Terminus\Exceptions\TerminusException
      */
     public function testConversionCommands(): void
     {
-        $this->terminus(sprintf('conversion:validate-gitignore %s', $this->siteName));
-
         $localSiteDirName = sprintf('%s_terminus_conversion_plugin', $this->siteName);
-        $localSitePath = $gitignoreFilePath = Files::buildPath(
+        $localSitePath = Files::buildPath(
             $_SERVER['HOME'],
             'pantheon-local-copies',
             $localSiteDirName
         );
-        $gitignoreFilePath = Files::buildPath($localSitePath, '.gitignore');
 
+        // Execute the command.
+        $this->terminus(sprintf('conversion:validate-gitignore %s', $this->siteName));
+
+        // Verify .gitignore file.
+        $gitignoreFilePath = Files::buildPath($localSitePath, '.gitignore');
         $this->assertTrue(
             is_file($gitignoreFilePath),
             sprintf('File "%s" must exist', $gitignoreFilePath)
         );
-
         $this->assertEquals(
             <<<EOD
 # Added by Terminus Conversion Tools Plugin.
@@ -52,6 +60,29 @@ final class ConversionCommandsValidateAndFixGitignoreTest extends ConversionComm
 
 EOD,
             file_get_contents($gitignoreFilePath)
+        );
+
+        $git = new Git($localSitePath);
+        $fs = new Filesystem();
+
+        // Before deleting Composer-installed assets.
+        $this->assertEmpty($git->diffFileList(), 'Git diff result must be empty.');
+
+        // After deleting some Composer-installed assets.
+        $fs->remove(Files::buildPath($localSitePath, 'vendor'));
+        $fs->remove(Files::buildPath($localSitePath, 'web/core'));
+        $fs->remove(Files::buildPath($localSitePath, 'web/modules/composer'));
+        $this->assertEmpty(
+            $git->diffFileList(),
+            'Git diff result must be empty after deleting Composer-installed assets.'
+        );
+
+        // After deleting some Composer-installed assets and a non-gitignored test file.
+        $fs->remove(Files::buildPath($localSitePath, 'web/themes/composer'));
+        $this->assertEquals(
+            ['web/themes/composer/this_file_must_not_be_gitignored.txt'],
+            $git->diffFileList(),
+            'Git diff must have exactly one deleted file "web/themes/composer/this_file_must_not_be_gitignored.txt"'
         );
     }
 }


### PR DESCRIPTION
<img width="900" alt="Screenshot 2022-04-04 at 09 28 35" src="https://user-images.githubusercontent.com/3658314/161479795-be1869b1-2288-4a4a-b712-3e914e559363.png">

### Example
* Before: `.gitignore` file either does not exist or is empty
* After: `.gitignore` file contents:
```
# Added by Terminus Conversion Tools Plugin.
/vendor
/web/core
/web/modules/composer/*
/web/themes/composer/*
!/web/themes/composer/a_committed_file.txt
```
Commits listing:
<img width="857" alt="Screenshot 2022-04-04 at 09 57 36" src="https://user-images.githubusercontent.com/3658314/161482509-74c64525-2c53-4caf-89be-68f13252ca50.png">

