### PR TITLE
[CMS-709] Update advise command for empty upstream.

### DIFF
--- a/src/Commands/AdviseCommand.php
+++ b/src/Commands/AdviseCommand.php
@@ -363,27 +363,47 @@ EOD
         }
 
         if ($isBuildTools) {
+            // @todo: Accept different branch name than default.
             if ($this->isConversionMultidevExist()) {
                 $this->adviseConversionMultidevExists();
             } else {
                 // Build artifact created by Terminus Build Tools plugin is present.
                 $this->output()->writeln(
                     <<<EOD
-Advice: you might want to convert to drupal-composer-managed if you are NOT using Continuous Integration (e.g. running tests, compiling css, etc).
-Otherwise, you should stay on "empty" upstream and the Terminus Build Tools (https://pantheon.io/docs/guides/build-tools/) workflow.
+Advice: convert to drupal-composer-managed either by preserving your Build Tools Workflow or by removing it if you are
+NOT using Continuous Integration (e.g. running tests, compiling css, etc).
 
-If you wish to convert to drupal-composer-managed, this process may be done manually by following the instructions in the guide:
+
+
+If you wish to preserve your Build Tools Workflow, you first need to push a branch to your source repository and
+create a Pull/Merge request there and wait for CI to push that to Pantheon. Once done, you should run the following command:
+
+    {$this->getTerminusExecutable()} conversion:composer {$this->site()->getName()} --branch=<branch-name>
+
+This command will update the existing multidev with the new upstream structure. Once you have tested this environment, the follow-on steps will be:
+
+    1) Merge the Pull/Merge request in your external VCS (e.g. GitHub)
+    2) Wait for CI to complete and push the branch to Pantheon
+    3) Set the right upstream using Terminus:
+
+        {$this->getTerminusExecutable()} site:upstream:set {$this->site()->getName()} drupal-composer-managed
+
+
+
+If you wish to remove your Build Tools Workflow, this process may be done manually by following the instructions in the guide:
 
     https://pantheon.io/docs/guides/composer-convert-from-empty
 
 An automated process to convert this site is available. To begin, run:
 
-    {$this->getTerminusExecutable()} conversion:composer {$this->site()->getName()}
+    {$this->getTerminusExecutable()} conversion:composer {$this->site()->getName()} --ignore-build-tools
 
-This command will create a new multidev named “conversion” that will contain a copy of your site converted to the recommended upstream. Once you have tested this environment, the follow-on steps will be:
+Once you have tested this environment, the follow-on steps will be:
 
     {$this->getTerminusExecutable()} conversion:release-to-dev {$this->site()->getName()}
     {$this->getTerminusExecutable()} site:upstream:set {$this->site()->getName()} drupal-composer-managed
+
+
 
 You may run the conversion:advise command again to check your progress and see the next steps again.
 EOD

--- a/src/Commands/Traits/ConversionCommandsTrait.php
+++ b/src/Commands/Traits/ConversionCommandsTrait.php
@@ -604,7 +604,7 @@ EOD,
             self::DRUPAL_TARGET_GIT_REMOTE_URL,
             self::DRUPAL_TARGET_UPSTREAM_ID
         );
-        return $this->areGitReposWithCommonCommits(self::DRUPAL_TARGET_UPSTREAM_ID);
+        return $this->areGitReposWithCommonCommits(self::DRUPAL_TARGET_UPSTREAM_ID, Git::DEFAULT_REMOTE, 'main');
     }
 
     /**

--- a/tests/functional/ConversionCommandsBuildToolsUpstreamTest.php
+++ b/tests/functional/ConversionCommandsBuildToolsUpstreamTest.php
@@ -34,7 +34,7 @@ final class ConversionCommandsBuildToolsUpstreamTest extends ConversionCommandsU
      */
     protected function getExpectedAdviceBeforeConversion(): string
     {
-        return 'you might want to convert to drupal-composer-managed if you are NOT using Continuous Integration';
+        return 'If you wish to preserve your Build Tools Workflow';
     }
 
     /**


### PR DESCRIPTION
New advise for a build tools site:

```
The site cms708 was created from the upstream:

    Empty Upstream (empty)

 [notice] Local git repository path is set to "/Users/kporras07/pantheon-local-copies/cms708_terminus_conversion_plugin".
Notice: This site was created by the process described by the Terminus Build Tools guide (https://pantheon.io/docs/guides/build-tools/).
Advice: convert to drupal-composer-managed either by preserving your Build Tools Workflow or by removing it if you are
NOT using Continuous Integration (e.g. running tests, compiling css, etc).



If you wish to preserve your Build Tools Workflow, you first need to push a branch to your source repository and
create a Pull/Merge request there and wait for CI to push that to Pantheon. Once done, you should run the following command:

    terminus conversion:composer cms708 --branch=<branch-name>

This command will update the existing multidev with the new upstream structure. Once you have tested this environment, the follow-on steps will be:

    1) Merge the Pull/Merge request in your external VCS (e.g. GitHub)
    2) Wait for CI to complete and push the branch to Pantheon
    3) Set the right upstream using Terminus:

        terminus site:upstream:set cms708 drupal-composer-managed



If you wish to remove your Build Tools Workflow, this process may be done manually by following the instructions in the guide:

    https://pantheon.io/docs/guides/composer-convert-from-empty

An automated process to convert this site is available. To begin, run:

    terminus conversion:composer cms708 --ignore-build-tools

Once you have tested this environment, the follow-on steps will be:

    terminus conversion:release-to-dev cms708
    terminus site:upstream:set cms708 drupal-composer-managed



You may run the conversion:advise command again to check your progress and see the next steps again.
```