### PR TITLE
[CMS-1015] Make import work in Drupal 10.

### DIFF
--- a/src/Commands/ImportSiteCommand.php
+++ b/src/Commands/ImportSiteCommand.php
@@ -187,7 +187,8 @@ EOD,
     /**
      * Set current php version for the site.
      */
-    private function setPhpVersion(string $path) {
+    private function setPhpVersion(string $path)
+    {
         $pantheonYmlContent = Yaml::parseFile(Files::buildPath($path, 'pantheon.yml'));
         preg_match('/(\d+\.\d+)/', phpversion(), $matches);
         if (!$matches[1]) {

--- a/src/Commands/ImportSiteCommand.php
+++ b/src/Commands/ImportSiteCommand.php
@@ -177,6 +177,9 @@ EOD,
 
         $this->executeDrushCacheRebuild($options, 'dev');
 
+        // A second cache clear seems to be needed.
+        $this->executeDrushCacheRebuild($options, 'dev');
+
         $this->log()->notice(sprintf('Link to "dev" environment dashboard: %s', $devEnv->dashboardUrl()));
         $this->log()->notice('Done!');
     }

--- a/src/Commands/ImportSiteCommand.php
+++ b/src/Commands/ImportSiteCommand.php
@@ -14,6 +14,7 @@ use Pantheon\TerminusConversionTools\Utils\Files;
 use Pantheon\TerminusConversionTools\Utils\Git;
 use PharData;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Class ImportSiteCommand.
@@ -181,6 +182,28 @@ EOD,
     }
 
     /**
+     * Set current php version for the site.
+     */
+    private function setPhpVersion(string $path) {
+        $pantheonYmlContent = Yaml::parseFile(Files::buildPath($path, 'pantheon.yml'));
+        preg_match('/(\d+\.\d+)/', phpversion(), $matches);
+        if (!$matches[1]) {
+            throw new TerminusException('An error occurred getting current php version.');
+        }
+        $phpVersion = $matches[1];
+        if ($phpVersion !== $pantheonYmlContent['php_version']) {
+            $pantheonYmlContent['php_version'] = (float) $phpVersion;
+            $pantheonYmlFile = fopen(Files::buildPath($path, 'pantheon.yml'), 'wa+');
+            fwrite($pantheonYmlFile, Yaml::dump($pantheonYmlContent, 2, 2));
+            fclose($pantheonYmlFile);
+        }
+
+        if ($this->getGit()->isAnythingToCommit()) {
+            $this->getGit()->commit('Set PHP version to ' . $phpVersion);
+        }
+    }
+
+    /**
      * Imports the code to the site.
      *
      * @param \Pantheon\Terminus\Models\Environment $env
@@ -206,6 +229,10 @@ EOD,
 
         $localPath = $this->getLocalSitePath();
         $this->setGit($localPath);
+
+        $this->setPhpVersion($localPath);
+        $this->getGit()->push(Git::DEFAULT_BRANCH);
+        $this->waitForSyncCodeWorkflow('dev');
 
         $this->log()->notice('Copying the site code from the archive...');
         $this->fs->mirror($codePath, $localPath);

--- a/src/Commands/Traits/MigrateComposerJsonTrait.php
+++ b/src/Commands/Traits/MigrateComposerJsonTrait.php
@@ -259,7 +259,12 @@ EOD
 
         $drupalPackage = $this->sourceHasDrupalCoreRecommended() ? 'drupal/core-recommended' : 'drupal/core';
 
-        $drupalIntegrationsConstraint = preg_match('/^[^0-9]*9/', $drupalConstraint) ? '^9' : '^8';
+        preg_match('/^\^?([0-9]{1,2}).*/', $drupalConstraint, $matches);
+        $drupalIntegrationsConstraint = "^" . $matches[1] ?? '^8|^9|^10';
+
+        if ($drupalIntegrationsConstraint === "^10") {
+            $this->getComposer()->config('platform.php', '8.1');
+        }
 
         $packages = [
             [
@@ -273,19 +278,22 @@ EOD
                 'is_dev' => false,
             ],
             [
+                'package' => 'drupal/core-composer-scaffold',
+                'version' => $drupalConstraint,
+                'is_dev' => false,
+            ],
+            [
                 'package' => 'drupal/core-dev',
                 'version' => $drupalConstraint,
                 'is_dev' => true,
             ],
         ];
 
-        if (preg_match('/^[^0-9]*8/', $drupalConstraint)) {
-            $packages[] = [
-                'package' => 'drush/drush',
-                'version' => '^10',
-                'is_dev' => false,
-            ];
-        }
+        $packages[] = [
+            'package' => 'drush/drush',
+            'version' => '^10|^11',
+            'is_dev' => false,
+        ];
 
         return $packages;
     }

--- a/src/Commands/Traits/MigrateComposerJsonTrait.php
+++ b/src/Commands/Traits/MigrateComposerJsonTrait.php
@@ -181,7 +181,7 @@ EOD
                 }
             }
 
-            $this->getComposer()->install('--no-dev');
+            $this->getComposer()->update('--no-dev');
             if ($this->getGit()->isAnythingToCommit()) {
                 $this->getGit()->commit('Install composer packages');
             }

--- a/src/Commands/Traits/MigrateComposerJsonTrait.php
+++ b/src/Commands/Traits/MigrateComposerJsonTrait.php
@@ -508,15 +508,18 @@ EOD
      */
     private function copyAllowPluginsConfiguration(): void
     {
-        if (!isset($this->sourceComposerJson['config']['allow-plugins'])) {
-            return;
+        $currentComposerJson = $this->getComposer()->getComposerJsonData();
+        $currentComposerJson['config']['allow-plugins']['drupal/core-project-message'] = true;
+        $currentComposerJson['config']['allow-plugins']['drupal/core-vendor-hardening'] = true;
+        $currentComposerJson['config']['allow-plugins']['phpstan/extension-installer'] = true;
+
+        if (isset($this->sourceComposerJson['config']['allow-plugins'])) {
+            $currentComposerJson['config']['allow-plugins'] = array_merge(
+                $currentComposerJson['config']['allow-plugins'],
+                $this->sourceComposerJson['config']['allow-plugins']
+            );
         }
 
-        $currentComposerJson = $this->getComposer()->getComposerJsonData();
-        $currentComposerJson['config']['allow-plugins'] = array_merge(
-            $currentComposerJson['config']['allow-plugins'] ?? [],
-            $this->sourceComposerJson['config']['allow-plugins']
-        );
         $this->getComposer()->writeComposerJsonData($currentComposerJson);
     }
 }

--- a/tests/functional/ConversionCommandsImportSiteTest.php
+++ b/tests/functional/ConversionCommandsImportSiteTest.php
@@ -112,6 +112,11 @@ class ConversionCommandsImportSiteTest extends ConversionCommandsTestBase
 
         $this->terminus($command);
         sleep(30);
+        $clearCacheComamnd = sprintf(
+            'drush %s.dev cr',
+            $this->siteName,
+        );
+        $this->terminus($clearCacheComamnd);
 
         $this->assertPagesExists(self::DEV_ENV);
 


### PR DESCRIPTION
To test:
- Create a Drupal 10 site in your local env using lando
- Export the database: lando db-export dump.sql
- Gunzip the file (gunzip dump.sql.gz)
- Running the brach version of the plugin, run the following command

```
terminus conversion:import-site siteName --org="$ORG_IF_NEEDED" --code_path=./sitepath --db_path=./sitepath/dump.sql --files_path=./sitepath/web/sites/default/files --yes
```