### PR TITLE
fix(VUL-24504): bump czproject/git-php from v4.0.2 to v4.0.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1664,16 +1664,16 @@
         },
         {
             "name": "czproject/git-php",
-            "version": "v4.0.2",
+            "version": "v4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/czproject/git-php.git",
-                "reference": "32505124ef2a8651f10a5afebace58f85eff2f93"
+                "reference": "5e82d5479da5f16d37a915de4ec55e1ac78de733"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/czproject/git-php/zipball/32505124ef2a8651f10a5afebace58f85eff2f93",
-                "reference": "32505124ef2a8651f10a5afebace58f85eff2f93",
+                "url": "https://api.github.com/repos/czproject/git-php/zipball/5e82d5479da5f16d37a915de4ec55e1ac78de733",
+                "reference": "5e82d5479da5f16d37a915de4ec55e1ac78de733",
                 "shasum": ""
             },
             "require": {
@@ -1704,7 +1704,7 @@
             ],
             "support": {
                 "issues": "https://github.com/czproject/git-php/issues",
-                "source": "https://github.com/czproject/git-php/tree/v4.0.2"
+                "source": "https://github.com/czproject/git-php/tree/v4.0.3"
             },
             "funding": [
                 {
@@ -1712,7 +1712,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2021-06-15T09:39:16+00:00"
+            "time": "2022-04-21T16:50:57+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
## Summary

Bumps `czproject/git-php` from `v4.0.2` to `v4.0.3` in `composer.lock` to address a command injection vulnerability.

Addresses: [VUL-24504](https://getpantheon.atlassian.net/browse/VUL-24504)

**Note:** The `twig/twig` CVE (CVE-2022-23614) is already addressed by the open Dependabot PR [#67](https://github.com/pantheon-systems/terminus-conversion-tools-plugin/pull/67), which bumps `twig/twig` from 3.3.3 to 3.11.0.

## CVEs Addressed

| Package | CVE | Severity | Description | Fixed In |
|---|---|---|---|---|
| czproject/git-php | [CVE-2022-25866](https://nvd.nist.gov/vuln/detail/CVE-2022-25866) | High | Command injection via unsanitized git arguments (CWE-74, CWE-77) | v4.0.3 |

## Changes

- **`composer.lock`** — Updated `czproject/git-php` version reference from `v4.0.2` (ref: `32505124`) to `v4.0.3` (ref: `5e82d547`).

  `czproject/git-php` is a **transitive dependency** (pulled in via dev dependencies) — it does not appear in `composer.json` directly, so only the lockfile is updated. Promoting it to a direct dependency would be incorrect.

## CVE Attribution

- **CVE-2022-25866** affects `czproject/git-php < 4.0.3`. The current lockfile pins `v4.0.2`; this PR bumps to the minimum patched version `v4.0.3`.
- **CVE-2022-23614** (twig/twig) is already addressed in open PR #67 — not duplicated here.

[VUL-24504]: https://getpantheon.atlassian.net/browse/VUL-24504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ